### PR TITLE
[ch16761] Only create custom test runner once for running all tests

### DIFF
--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -2,6 +2,9 @@
 #![feature(internal_output_capture)]
 #![test_runner(e2e_test_runner)]
 
+#[cfg(test)]
+mod tests;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{stream, FutureExt, StreamExt};

--- a/e2e/src/tests/hello_world1.rs
+++ b/e2e/src/tests/hello_world1.rs
@@ -1,11 +1,8 @@
-#![feature(custom_test_frameworks)]
-#![test_runner(e2e::e2e_test_runner)]
-
+use crate::Context;
 use anyhow::Result;
-use e2e::Context;
 
 #[test_case]
-async fn hello_world(ctx: Context) -> Result<()> {
+async fn hello_world1(ctx: Context) -> Result<()> {
     ctx.page
         .goto_builder("http://127.0.0.1:8000")
         .goto()

--- a/e2e/src/tests/hello_world2.rs
+++ b/e2e/src/tests/hello_world2.rs
@@ -1,11 +1,8 @@
-#![feature(custom_test_frameworks)]
-#![test_runner(e2e::e2e_test_runner)]
-
+use crate::Context;
 use anyhow::Result;
-use e2e::Context;
 
 #[test_case]
-async fn hello_world(ctx: Context) -> Result<()> {
+async fn hello_world2(ctx: Context) -> Result<()> {
     ctx.page
         .goto_builder("http://127.0.0.1:8000")
         .goto()

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod hello_world1;
+pub mod hello_world2;


### PR DESCRIPTION
It seems that the only way to make cargo aggregate all tests into one run, is to make them part of the same crate (i.e. not in a `tests` folder that is sibling to `src`), so with this change, it now runs all tests in the same test runner instantiation.